### PR TITLE
fix: Peer dependencies for NPM 7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "release": "yarn compile && npx semantic-release"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": ">16.2.0",
+    "react-dom": ">16.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
The way peer dependencies are handled has changed in NPM 7 and higher. Now NPM will attempt to install peer dependencies and fail if they cannot be installed, rather than simply suggesting they be installed.

The existing peer dependency in package.json is actually equivalent to: 'any version of React within the 16.2.X series and no higher' which is obviously not the intention as this is a package for React 18. At the time this was setup this wouldn't have caused a problem since NPM didn't insist upon installing peer dependencies but now anyone with an up to date version of NPM cannot install this package and will receive an error like so:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: yourpackage@1.0
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.2.0" from react-callback@1.1.0
npm ERR! node_modules/react-callback
npm ERR!   react-callback@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Although --force or --legacy-peer-deps will temporarily fix the issue it's not an ideal solution.

This commit is the minimal change in order to correct this: changing the peer dependency entry to mean 'any version higher than 16.2.0' which was probably the original intention.